### PR TITLE
Add targets and remove older VS versions

### DIFF
--- a/Source/MSBuild.Common.Sdk/Build/Microsoft.VisualStudio.props
+++ b/Source/MSBuild.Common.Sdk/Build/Microsoft.VisualStudio.props
@@ -1,14 +1,10 @@
 <Project>
 
 	<PropertyGroup Condition="'$(VisualStudioVersion)' == '' AND !Exists('$(VSToolsPath)')">
-		<MinVisualStudioVersion>10.0</MinVisualStudioVersion>
+		<MinVisualStudioVersion>15.0</MinVisualStudioVersion>
 		<BaseVSToolsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio</BaseVSToolsPath>
 
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v$(MinVisualStudioVersion)')">$(MinVisualStudioVersion)</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v11.0')">11.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v12.0')">12.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v14.0')">14.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v15.0')">15.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v16.0')">16.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v17.0')">17.0</VisualStudioVersion>
 

--- a/Source/MSBuild.Core.Sdk/Build/Microsoft.VisualStudio.props
+++ b/Source/MSBuild.Core.Sdk/Build/Microsoft.VisualStudio.props
@@ -1,14 +1,10 @@
 <Project>
 
 	<PropertyGroup Condition="'$(VisualStudioVersion)' == '' AND !Exists('$(VSToolsPath)')">
-		<MinVisualStudioVersion>10.0</MinVisualStudioVersion>
+		<MinVisualStudioVersion>15.0</MinVisualStudioVersion>
 		<BaseVSToolsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio</BaseVSToolsPath>
 
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v$(MinVisualStudioVersion)')">$(MinVisualStudioVersion)</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v11.0')">11.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v12.0')">12.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v14.0')">14.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v15.0')">15.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v16.0')">16.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v17.0')">17.0</VisualStudioVersion>
 

--- a/Source/MSBuild.Project.Sdk/Build/Microsoft.VisualStudio.props
+++ b/Source/MSBuild.Project.Sdk/Build/Microsoft.VisualStudio.props
@@ -1,14 +1,10 @@
 <Project>
 
 	<PropertyGroup Condition="'$(VisualStudioVersion)' == '' AND !Exists('$(VSToolsPath)')">
-		<MinVisualStudioVersion>10.0</MinVisualStudioVersion>
+		<MinVisualStudioVersion>15.0</MinVisualStudioVersion>
 		<BaseVSToolsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio</BaseVSToolsPath>
 
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v$(MinVisualStudioVersion)')">$(MinVisualStudioVersion)</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v11.0')">11.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v12.0')">12.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v14.0')">14.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v15.0')">15.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v16.0')">16.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v17.0')">17.0</VisualStudioVersion>
 

--- a/Source/MSBuild.Project.Sdk/Core/MSBuild.Defaults.targets
+++ b/Source/MSBuild.Project.Sdk/Core/MSBuild.Defaults.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project InitialTargets="Initialize" DefaultTargets="Summary">
 
 	<PropertyGroup>
 		<ProjectName Condition="'$(ProjectName)' == ''">$(MSBuildProjectName)</ProjectName>
@@ -26,5 +26,23 @@
 		<BuildContext Condition="!('$(BuildContext)' == '' OR $(BuildContext.EndsWith('-')))">$(BuildContext)-</BuildContext>
 		<BuildContext>$(BuildContext)$(Platform)</BuildContext>
 	</PropertyGroup>
+
+	<!--
+	========================================================================================================================
+														TARGETS
+	========================================================================================================================
+	-->
+
+	<!-- Initial Target for the Project Context -->
+
+	<Target Name="Initialize" DependsOnTargets="$(InitializeDependsOn)">
+		<Message Importance="Low" Text="$(MSBuildProjectName) is initialized."/>
+	</Target>
+
+	<!-- Default Target for the Project Context -->
+
+	<Target Name="Summary" DependsOnTargets="$(SummaryDependsOn)">
+		<Message Importance="High" Text="$(MSBuildProjectName) ($(Configuration)|$(Platform)) [$(MSBuildProjectDirectory)]"/>
+	</Target>
 
 </Project>

--- a/Source/MSBuild.Solution.Sdk/Build/Microsoft.VisualStudio.props
+++ b/Source/MSBuild.Solution.Sdk/Build/Microsoft.VisualStudio.props
@@ -1,14 +1,10 @@
 <Project>
 
 	<PropertyGroup Condition="'$(VisualStudioVersion)' == '' AND !Exists('$(VSToolsPath)')">
-		<MinVisualStudioVersion>10.0</MinVisualStudioVersion>
+		<MinVisualStudioVersion>15.0</MinVisualStudioVersion>
 		<BaseVSToolsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio</BaseVSToolsPath>
 
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v$(MinVisualStudioVersion)')">$(MinVisualStudioVersion)</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v11.0')">11.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v12.0')">12.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v14.0')">14.0</VisualStudioVersion>
-		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v15.0')">15.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v16.0')">16.0</VisualStudioVersion>
 		<VisualStudioVersion Condition="Exists('$(BaseVSToolsPath)\v17.0')">17.0</VisualStudioVersion>
 

--- a/Source/MSBuild.Solution.Sdk/Core/MSBuild.Defaults.targets
+++ b/Source/MSBuild.Solution.Sdk/Core/MSBuild.Defaults.targets
@@ -1,4 +1,4 @@
-<Project DefaultTargets="Restore;Build">
+<Project InitialTargets="Initialize" DefaultTargets="Summary">
 
 	<PropertyGroup>
 		<SolutionName Condition="'$(SolutionName)' == ''">$(MSBuildSolutionName)</SolutionName>
@@ -25,5 +25,23 @@
 		<BuildContext Condition="!('$(BuildContext)' == '' OR $(BuildContext.EndsWith('-')))">$(BuildContext)-</BuildContext>
 		<BuildContext>$(BuildContext)$(Platform)</BuildContext>
 	</PropertyGroup>
+
+	<!--
+	========================================================================================================================
+														TARGETS
+	========================================================================================================================
+	-->
+
+	<!-- Initial Target for the Solution Context -->
+
+	<Target Name="Initialize" DependsOnTargets="$(InitializeDependsOn)">
+		<Message Importance="Low" Text="$(MSBuildSolutionName) is initialized."/>
+	</Target>
+
+	<!-- Default Target for the Solution Context -->
+
+	<Target Name="Summary" DependsOnTargets="$(SummaryDependsOn)">
+		<Message Importance="High" Text="$(MSBuildSolutionName) ($(Configuration)|$(Platform)) [$(MSBuildSolutionDirectory)]"/>
+	</Target>
 
 </Project>


### PR DESCRIPTION
### Add Initial and Default targets

Add Initialize as the initial targets and Summary as the default targets for both the project and solution SDKs. We don't need to add this to other SDKs since they have different purposes and compat reasoning than these ones.

### Raise Minimum Visual Studio version to Dev15

We still support importing targets from VS versions < v15, but MSBuild only supports SDK-style projects from v15 onwards. So, disable older versions explicitly but if people want to refer to older targets, they can override the 'VSToolsPath' since it is present in props rather than targets as supposed to be case in older MSBuild targets. Since we have already seen two releases after Dev15, it's time to drop the older versions.